### PR TITLE
uwu-ify

### DIFF
--- a/src/commands/uwu-ify.ts
+++ b/src/commands/uwu-ify.ts
@@ -1,0 +1,40 @@
+import {Command} from "@ubccpsc310/bot-base";
+import {Client, Message} from "discord.js";
+
+const uwuify: Command = {
+	name: "uwu-ify",
+	description: "let binds all words to uwus and (format)s them back together",
+	usage: "uwu-ify <message>?",
+	async procedure(client: Client, message: Message, args: string[]): Promise<Message> {
+		if (!args.length) {
+			return message.channel.send(`(let ([uwu "uwu"])\n  (format ~a uwu))`);
+		}
+
+		const binding_map = args.reduce((acc, curr) => {
+			return {...acc, [curr]: `uwu${Object.keys(acc).length}`};
+		}, {});
+
+		const binding_info = Object.keys(binding_map).reduce(
+			(acc, curr) => {
+				return {
+					str:
+						`${acc.str}${acc.newline ? `\n` : ``}` +
+						`${`  `.repeat(acc.line_number)}` +
+						`(let ([${binding_map[curr]} "${curr}"])`,
+					newline: true,
+					line_number: ++acc.line_number,
+				};
+			},
+			{str: ``, newline: false, line_number: 0} satisfies {str: string; newline: boolean; line_number: number}
+		);
+
+		return message.channel.send(
+			binding_info.str +
+				`\n${`  `.repeat(binding_info.line_number)}` +
+				`(format "${"~a ".repeat(binding_info.line_number).trim()}" ${Object.values(binding_map).join(" ")})` +
+				`)`.repeat(binding_info.line_number)
+		);
+	},
+};
+
+export default uwuify;

--- a/src/commands/uwu-ify.ts
+++ b/src/commands/uwu-ify.ts
@@ -18,7 +18,8 @@ const uwuify: Command = {
 			(acc, curr) => {
 				return {
 					str:
-						`${acc.str}${acc.newline ? `\n` : ``}` +
+						acc.str +
+						`${acc.newline ? `\n` : ``}` +
 						`${`  `.repeat(acc.line_number)}` +
 						`(let ([${binding_map[curr]} "${curr}"])`,
 					newline: true,

--- a/src/commands/uwu-ify.ts
+++ b/src/commands/uwu-ify.ts
@@ -7,7 +7,7 @@ const uwuify: Command = {
 	usage: "uwu-ify <message>?",
 	async procedure(client: Client, message: Message, args: string[]): Promise<Message> {
 		if (!args.length) {
-			return message.channel.send(`(let ([uwu "uwu"])\n  (format ~a uwu))`);
+			return message.channel.send(`\`\`\`lisp\n` + `(let ([uwu "uwu"])\n` + `  (format ~a uwu))\n\`\`\``);
 		}
 
 		const binding_map = args.reduce((acc, curr) => {
@@ -30,10 +30,12 @@ const uwuify: Command = {
 		);
 
 		return message.channel.send(
-			binding_info.str +
+			`\`\`\`lisp\n` +
+				binding_info.str +
 				`\n${`  `.repeat(binding_info.line_number)}` +
 				`(format "${"~a ".repeat(binding_info.line_number).trim()}" ${Object.values(binding_map).join(" ")})` +
-				`)`.repeat(binding_info.line_number)
+				`)`.repeat(binding_info.line_number) +
+				`\n\`\`\``
 		);
 	},
 };

--- a/src/commands/uwu-ify.ts
+++ b/src/commands/uwu-ify.ts
@@ -20,7 +20,7 @@ const uwuify: Command = {
 					str:
 						acc.str +
 						`${acc.newline ? `\n` : ``}` +
-						`${`  `.repeat(acc.line_number)}` +
+						`  `.repeat(acc.line_number) +
 						`(let ([${binding_map[curr]} "${curr}"])`,
 					newline: true,
 					line_number: ++acc.line_number,
@@ -32,8 +32,10 @@ const uwuify: Command = {
 		return message.channel.send(
 			`\`\`\`lisp\n` +
 				binding_info.str +
-				`\n${`  `.repeat(binding_info.line_number)}` +
-				`(format "${"~a ".repeat(binding_info.line_number).trim()}" ${Object.values(binding_map).join(" ")})` +
+				`\n` +
+				`  `.repeat(binding_info.line_number) +
+				`(format "${"~a ".repeat(binding_info.line_number).trim()}"` +
+				Object.values(binding_map).join(" ") +
 				`)`.repeat(binding_info.line_number) +
 				`\n\`\`\``
 		);


### PR DESCRIPTION
haven't been able to run the bot locally, but this is how the function works

```ts
// input
[]
// output
"```lisp
(let ([uwu "uwu"])
  (format ~a uwu))
```"

// input
["aaaa"]
// output
"```lisp
(let ([uwu0 "aaaa"])
  (format "~a" uwu0))
```"
// input
[
  'have',       'no',
  'truck',      'with',
  'the',        'grubby',
  'promises',   'of',
  'imperative', 'programming'
]
// output
"```lisp
(let ([uwu0 "have"])
  (let ([uwu1 "no"])
    (let ([uwu2 "truck"])
      (let ([uwu3 "with"])
        (let ([uwu4 "the"])
          (let ([uwu5 "grubby"])
            (let ([uwu6 "promises"])
              (let ([uwu7 "of"])
                (let ([uwu8 "imperative"])
                  (let ([uwu9 "programming"])
                    (format "~a ~a ~a ~a ~a ~a ~a ~a ~a ~a" uwu0 uwu1 uwu2 uwu3 uwu4 uwu5 uwu6 uwu7 uwu8 uwu9)))))))))))
```"
```

and it's valid racket, so you can throw into a racket REPL to get your original message back

(is this a compiler???)